### PR TITLE
add client_id and client_secret when calling github api

### DIFF
--- a/app/services/github.service.ts
+++ b/app/services/github.service.ts
@@ -13,12 +13,12 @@ export class GithubService{
     }
     
     getUser(){
-        return this._http.get('https://api.github.com/users/'+this.username)
+        return this._http.get('https://api.github.com/users/'+this.username+'?client_id='+this.client_id+'&client_secret='+this.client_secret)
             .map(res => res.json());
     }
     
     getRepos(){
-        return this._http.get('https://api.github.com/users/'+this.username+'/repos')
+        return this._http.get('https://api.github.com/users/'+this.username+'/repos?client_id='+this.client_id+'&client_secret='+this.client_secret)
             .map(res => res.json());
     }
     


### PR DESCRIPTION
GitHub's rate limit kicks in very early while trying to follow this excellent walkthrough, unless you add these to the request.